### PR TITLE
GitHub Pages tweaks for custom domain & nojekyll

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: Deploy build to gh-pages branch
           command: |
             echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-            touch .nojekyll  # Disable Jekyll processing on GitHub Pages
+            touch build/.nojekyll  # Disable Jekyll processing on GitHub Pages
             echo search.het.io > build/CNAME  # set custom GitHub Pages domain
             gh-pages --dist build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
           name: Deploy build to gh-pages branch
           command: |
             echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+            touch .nojekyll  # Disable Jekyll processing on GitHub Pages
+            echo search.het.io > build/CNAME  # set custom GitHub Pages domain
             gh-pages --dist build
 
 workflows:


### PR DESCRIPTION
This will configure GitHub Pages to use the custom domain https://search.het.io.