### PR TITLE
fetch metanode colors from external json, update svgs

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,7 @@
 export function setDefinitions({
   metagraph,
   hetioDefinitions,
+  hetioStyles,
   hetmechDefinitions
 }) {
   return {
@@ -11,6 +12,7 @@ export function setDefinitions({
     payload: {
       metagraph: metagraph,
       hetioDefinitions: hetioDefinitions,
+      hetioStyles: hetioStyles,
       hetmechDefinitions: hetmechDefinitions
     }
   };

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import { MetapathResults } from './metapath-results.js';
 import { getMetagraph } from './backend-query.js';
 import { getHetioDefinitions } from './backend-query.js';
 import { getHetmechDefinitions } from './backend-query.js';
+import { getHetioStyles } from './backend-query.js';
 import { lookupNodeById } from './backend-query.js';
 import { searchMetapaths } from './backend-query.js';
 import { setDefinitions } from './actions.js';
@@ -52,6 +53,7 @@ class App extends Component {
       const promises = [
         getMetagraph(),
         getHetioDefinitions(),
+        getHetioStyles(),
         getHetmechDefinitions()
       ];
       Promise.all(promises).then((results) => {
@@ -59,7 +61,8 @@ class App extends Component {
           setDefinitions({
             metagraph: results[0],
             hetioDefinitions: results[1],
-            hetmechDefinitions: results[2]
+            hetioStyles: results[2],
+            hetmechDefinitions: results[3]
           })
         );
       });

--- a/src/arrow-icon-backward.svg
+++ b/src/arrow-icon-backward.svg
@@ -1,32 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <line
-    x1="10"
-    y1="50"
-    x2="90"
-    y2="50"
+  <path
+    fill="none"
     stroke="currentColor"
     stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <line
-    x1="30"
-    y1="35"
-    x2="10"
-    y2="50"
-    stroke="currentColor"
-    stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <line
-    x1="30"
-    y1="65"
-    x2="10"
-    y2="50"
-    stroke="currentColor"
-    stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
+    d="
+      M 90 50
+      L 10 50
+      M 30 35
+      L 10 50
+      L 30 65
+    "
+  ></path>
 </svg>

--- a/src/arrow-icon-both.svg
+++ b/src/arrow-icon-both.svg
@@ -1,12 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <line
-    x1="10"
-    y1="50"
-    x2="90"
-    y2="50"
+  <path
+    fill="none"
     stroke="currentColor"
     stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
+    d="
+      M 90 50
+      L 10 50
+    "
+  ></path>
 </svg>

--- a/src/arrow-icon-forward.svg
+++ b/src/arrow-icon-forward.svg
@@ -1,32 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <line
-    x1="10"
-    y1="50"
-    x2="90"
-    y2="50"
+  <path
+    fill="none"
     stroke="currentColor"
     stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <line
-    x1="70"
-    y1="35"
-    x2="90"
-    y2="50"
-    stroke="currentColor"
-    stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <line
-    x1="70"
-    y1="65"
-    x2="90"
-    y2="50"
-    stroke="currentColor"
-    stroke-width="10"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
+    d="
+      M 90 50
+      L 10 50
+      M 70 35
+      L 90 50
+      L 70 65
+    "
+  ></path>
 </svg>

--- a/src/backend-query.js
+++ b/src/backend-query.js
@@ -6,6 +6,9 @@ const metagraphUrl =
 // url for hetio definitions (metanodes, properties, etc)
 const hetioDefinitions =
   'https://raw.githubusercontent.com/hetio/hetionet/master/describe/definitions.json';
+// url for hetio styles (metanode fill/text color, etc)
+const hetioStyles =
+  'https://raw.githubusercontent.com/hetio/hetionet/master/describe/styles.json';
 // url for node search
 const nodeSearchServer = 'https://search-api.het.io/v1/nodes/';
 // url for paths search
@@ -32,6 +35,11 @@ export function getMetagraph() {
 // get hetio definitions
 export function getHetioDefinitions() {
   return fetchJson(hetioDefinitions);
+}
+
+// get hetio styles
+export function getHetioStyles() {
+  return fetchJson(hetioStyles);
 }
 
 // get hetmech definitions

--- a/src/chip-anatomy.svg
+++ b/src/chip-anatomy.svg
@@ -1,21 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#4caf50"></circle>
   <clipPath id="clip">
-    <rect x="-10" y="-10" width="120" height="120"></rect>
+    <rect x="0" y="0" width="100" height="100"></rect>
   </clipPath>
-  <path
-    transform="translate(50,50) scale(0.45) translate(-50,-50)"
-    fill="none"
-    stroke="#fafafa"
-    stroke-width="20"
-    stroke-linecap="square"
-    clip-path="url(#clip)"
-    d="
-      M 5 110
-      L 50 0
-      L 95 110
-      M 30 70
-      L 70 70
-    "
-  ></path>
+  <g>
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="20"
+      stroke-linecap="square"
+      transform="translate(50,50) scale(0.5) translate(-50,-50)"
+      clip-path="url(#clip)"
+      d="
+        M 10 110
+        L 50 0
+        L 90 110
+        M 30 70
+        L 70 70
+      "
+    ></path>
+  </g>
 </svg>

--- a/src/chip-biological-process.svg
+++ b/src/chip-biological-process.svg
@@ -1,33 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#fa750f"></circle>
   <path
-    transform="translate(-16,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
+    stroke-linecap="square"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(-44,0)"
     d="
-      M 20 0
-      L 60 0
-      A 25 25 0 0 1 60 50
-      A 25 25 0 0 1 60 100
-      L 22 100
+      M 25 10
+      L 60 10
+      A 20 20 0 0 1 60 50
+      A 20 20 0 0 1 60 90
+      L 25 90
       Z
-      M 20 50
+      M 30 50
       L 60 50
     "
   ></path>
   <path
-    transform="translate(16,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(44,0)"
     d="
-      M 20 100
-      L 20 0
-      L 60 0
-      A 25 25 0 0 1 60 50
-      L 22 50
+      M 25 90
+      L 25 10
+      L 60 10
+      A 20 20 0 0 1 60 50
+      L 30 50
     "
   ></path>
 </svg>

--- a/src/chip-cellular-component.svg
+++ b/src/chip-cellular-component.svg
@@ -1,23 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#fa750f"></circle>
   <path
-    transform="translate(-17,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(-43,0)"
     d="
-      M 85.355339059 14.644660941
-      A 50 50 0 1 0 85.355339059 85.355339059
+      M 78.2842706364495 21.7157281415257
+      A 40 40 0 1 0 78.2842755245486 78.2842669703746
     "
   ></path>
   <path
-    transform="translate(19,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(48,0)"
     d="
-      M 85.355339059 14.644660941
-      A 50 50 0 1 0 85.355339059 85.355339059
+      M 78.2842706364495 21.7157281415257
+      A 40 40 0 1 0 78.2842755245486 78.2842669703746
     "
   ></path>
 </svg>

--- a/src/chip-compound.svg
+++ b/src/chip-compound.svg
@@ -1,13 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#e91e63"></circle>
   <path
-    transform="translate(50,50) scale(0.45) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
+    stroke="currentColor"
     stroke-width="20"
+    transform="translate(50,50) scale(0.5) translate(-50,-50)"
     d="
-      M 85.355339059 14.644660941
-      A 50 50 0 1 0 85.355339059 85.355339059
+      M 78.2842706364495 21.7157281415257
+      A 40 40 0 1 0 78.2842755245486 78.2842669703746
     "
   ></path>
 </svg>

--- a/src/chip-disease.svg
+++ b/src/chip-disease.svg
@@ -1,15 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#875442"></circle>
   <path
-    transform="translate(50,50) scale(0.45) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
+    stroke="currentColor"
     stroke-width="20"
+    transform="translate(50,50) scale(0.5) translate(-50,-50)"
     d="
-      M 15 0
-      L 50 0
-      A 50 50 0 0 1 50 100
-      L 15 100
+      M 25 10
+      L 50 10
+      A 40 40 0 0 1 50 90
+      L 25 90
       Z
     "
   ></path>

--- a/src/chip-gene.svg
+++ b/src/chip-gene.svg
@@ -1,14 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#02b3e4"></circle>
   <path
-    transform="translate(50,50) scale(0.45) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
+    stroke="currentColor"
     stroke-width="20"
+    transform="translate(50,50) scale(0.5) translate(-50,-50)"
     d="
-      M 85.355339059 14.644660941
-      A 50 50 0 1 0 85.355339059 85.355339059
-      L 85.355339059 50
+      M 78.2842706364495 21.7157281415257
+      A 40 40 0 1 0 78.2842755245486 78.2842669703746
+      L 78.2842755245486 50
       L 50 50
     "
   ></path>

--- a/src/chip-molecular-function.svg
+++ b/src/chip-molecular-function.svg
@@ -1,35 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#fa750f"></circle>
   <clipPath id="clip">
-    <rect x="-10" y="-10" width="120" height="120"></rect>
+    <rect x="0" y="0" width="100" height="100"></rect>
   </clipPath>
   <path
-    transform="translate(-16,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
     stroke-linejoin="bevel"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(-40,0)"
     clip-path="url(#clip)"
     d="
-      M 10 100
+      M 10 90
       L 10 -10
       L 50 65
       L 90 -10
-      L 90 100
+      L 90 90
     "
   ></path>
   <path
-    transform="translate(19,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(60,0)"
     d="
-      M 80 0
-      L 20 0
-      L 20 100
-      M 22 50
+      M 75 10
+      L 25 10
+      L 25 90
+      M 30 50
       L 65 50
     "
   ></path>

--- a/src/chip-pathway.svg
+++ b/src/chip-pathway.svg
@@ -1,36 +1,35 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#fa750f"></circle>
-  <clipPath id="clip">
-    <rect x="-20" y="-10" width="140" height="120"></rect>
-  </clipPath>
   <path
-    transform="translate(-20,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="25"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(-52,0)"
     d="
-      M 20 100
-      L 20 0
-      L 60 0
-      A 25 25 0 0 1 60 50
-      L 22 50
+    M 25 90
+    L 25 10
+    L 60 10
+    A 20 20 0 0 1 60 50
+    L 30 50
     "
   ></path>
+  <clipPath id="clip">
+    <rect x="0" y="0" width="100" height="100"></rect>
+  </clipPath>
   <path
-    transform="translate(15,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
     stroke-linejoin="bevel"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(45,0)"
     clip-path="url(#clip)"
     d="
-      M 0 -10
-      L 20 110
+      M 10 -10
+      L 25 100
       L 50 35
-      L 80 110
-      L 100 -10
+      L 75 100
+      L 90 -10
     "
   ></path>
 </svg>

--- a/src/chip-pharmacologic-class.svg
+++ b/src/chip-pharmacologic-class.svg
@@ -1,27 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#c341d8"></circle>
   <path
-    transform="translate(-18,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(-50,0)"
     d="
-      M 20 100
-      L 20 0
-      L 60 0
-      A 25 25 0 0 1 60 50
-      L 22 50
+      M 25 90
+      L 25 10
+      L 60 10
+      A 20 20 0 0 1 60 50
+      L 30 50
     "
   ></path>
   <path
-    transform="translate(19,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(48,0)"
     d="
-      M 85.355339059 14.644660941
-      A 50 50 0 1 0 85.355339059 85.355339059
+      M 78.2842706364495 21.7157281415257
+      A 40 40 0 1 0 78.2842755245486 78.2842669703746
     "
   ></path>
 </svg>

--- a/src/chip-side-effect.svg
+++ b/src/chip-side-effect.svg
@@ -1,32 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#ffeb3b"></circle>
   <path
-    transform="translate(-16,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#424242"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(-42,0)"
     d="
-      M 85 10
-      C 75 5 65 0 50 0
-      C 40 0 15 5 15 25
-      C 15 45 35 48 50 50
-      C 65 52 85 55 85 75
-      C 85 95 60 100 50 100
-      C 35 100 25 95 15 90
+      M 80 18
+      C 70 14 62 10 50 10
+      C 42 10 22 14 22 30
+      C 22 46 38 48.4 50 50
+      C 62 51.6 78 54 78 70
+      C 78 86 59 90 50 90
+      C 38 90 30 86 20 82
     "
   ></path>
   <path
-    transform="translate(16,0) translate(50,50) scale(0.3) translate(-50,-50)"
     fill="none"
-    stroke="#424242"
-    stroke-width="24"
+    stroke="currentColor"
+    stroke-width="20"
     stroke-linecap="square"
+    transform="translate(50,50) scale(0.4) translate(-50,-50) translate(42,0)"
     d="
-      M 80 0
-      L 20 0
-      L 20 100
-      L 80 100
-      M 25 50
+      M 75 10
+      L 25 10
+      L 25 90
+      L 75 90
+      M 30 50
       L 65 50
     "
   ></path>

--- a/src/chip-symptom.svg
+++ b/src/chip-symptom.svg
@@ -1,18 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="49" fill="#607d8b"></circle>
+  <clipPath id="clip">
+    <rect x="0" y="0" width="100" height="100"></rect>
+  </clipPath>
   <path
-    transform="translate(50,50) scale(0.45) translate(-50,-50)"
     fill="none"
-    stroke="#fafafa"
+    stroke="currentColor"
     stroke-width="20"
+    transform="translate(50,50) scale(0.5) translate(-50,-50)"
+    clip-path="url(#clip)"
     d="
-      M 85 10
-      C 75 5 65 0 50 0
-      C 40 0 15 5 15 25
-      C 15 45 35 48 50 50
-      C 65 52 85 55 85 75
-      C 85 95 60 100 50 100
-      C 35 100 25 95 15 90
+      M 80 18
+      C 70 14 62 10 50 10
+      C 42 10 22 14 22 30
+      C 22 46 38 48.4 50 50
+      C 62 51.6 78 54 78 70
+      C 78 86 59 90 50 90
+      C 38 90 30 86 20 82
     "
   ></path>
 </svg>

--- a/src/chip-unknown.svg
+++ b/src/chip-unknown.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle
-    cx="50"
-    cy="50"
-    r="49"
-    fill="#424242"
-  ></circle>
-</svg>

--- a/src/metanode-chip.css
+++ b/src/metanode-chip.css
@@ -1,5 +1,6 @@
 .metanode_chip {
   display: inline-flex;
+  position: relative;
   width: 20px;
   height: 20px;
   min-width: 20px;
@@ -12,6 +13,9 @@
   align-items: center;
 }
 .metanode_chip > svg {
+  position: absolute;
+  left: 0;
+  top: 0;
   width: 20px;
   height: 20px;
 }

--- a/src/metanode-chip.js
+++ b/src/metanode-chip.js
@@ -19,7 +19,6 @@ import { ReactComponent as CellularComponent } from './chip-cellular-component.s
 import { ReactComponent as MolecularFunction } from './chip-molecular-function.svg';
 import { ReactComponent as Pathway } from './chip-pathway.svg';
 import { ReactComponent as PharmacologicClass } from './chip-pharmacologic-class.svg';
-import { ReactComponent as Unknown } from './chip-unknown.svg';
 
 // metanode 'chip' component
 // colored circle with abbreviation text in middle
@@ -64,13 +63,31 @@ export class MetanodeChip extends Component {
         icon = <PharmacologicClass />;
         break;
       default:
-        icon = <Unknown />;
         break;
     }
 
-    return <div className='metanode_chip'>{icon}</div>;
+    let fillColor = '#424242';
+    let textColor = '#fafafa';
+    const style = this.props.hetioStyles[this.props.type];
+    if (style && style.fill_color)
+      fillColor = style.fill_color;
+    if (style && style.text_color)
+      textColor = style.text_color;
+
+    return (
+      <div className='metanode_chip' style={{ color: textColor }}>
+        <svg viewBox='0 0 100 100'>
+          <circle cx='50' cy='50' r='49' fill={fillColor} />
+        </svg>
+        {icon}
+      </div>
+    );
   }
 }
+// connect component to global state
+MetanodeChip = connect((state) => ({
+  hetioStyles: state.hetioStyles
+}))(MetanodeChip);
 
 // metaedge 'chip' component
 // svg arrow with abbreviation text above

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -11,6 +11,8 @@ export function Reducer(previousState = {}, action) {
         newState.metagraph = action.payload.metagraph;
       if (action.payload.hetioDefinitions !== undefined)
         newState.hetioDefinitions = action.payload.hetioDefinitions;
+      if (action.payload.hetioStyles !== undefined)
+        newState.hetioStyles = action.payload.hetioStyles;
       if (action.payload.hetmechDefinitions !== undefined)
         newState.hetmechDefinitions = action.payload.hetmechDefinitions;
       break;
@@ -46,6 +48,8 @@ export function Reducer(previousState = {}, action) {
     newState.metagraph = {};
   if (!newState.hetioDefinitions)
     newState.hetioDefinitions = {};
+  if (!newState.hetioStyles)
+    newState.hetioStyles = {};
   if (!newState.hetmechDefinitions)
     newState.hetmechDefinitions = {};
   if (!newState.sourceNode)


### PR DESCRIPTION
This PR changes the metanode "chips" (the circles with the letters in them) to get their color from an external `style.json` definitions file (from the hetionet repo) instead of having their color hard-coded into the svgs.

Modifying the design of the svgs was necessary because of this. I also updated the arrow svgs to be square instead of rounded, since everything else in the design is squared.

@dongbohu @dhimmel 