### PR TITLE
improve tooltip behavior and appearance

### DIFF
--- a/src/tooltip.css
+++ b/src/tooltip.css
@@ -10,14 +10,10 @@
   background: #000000;
   color: #fafafa;
   font-size: 0.75em;
-  transform: translate(0, -125%);
+  transform: translate(0, calc(-100% - 5px));
   user-select: none;
   pointer-events: none;
   transition: opacity 1s ease;
-}
-.tooltip_hitbox {
-  /* display: inline-block; */
-  z-index: 99999;
 }
 @media (hover: none) {
   .tooltip {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -6,7 +6,7 @@ import Fade from '@material-ui/core/Fade';
 import './tooltip.css';
 
 // open delay in ms
-const delay = 500;
+const delay = 1000;
 
 // tooltip (helper text) popup component
 export class Tooltip extends Component {
@@ -29,29 +29,28 @@ export class Tooltip extends Component {
   }
 
   // when mouse enters hitbox
-  onMouseEnter() {
+  onMouseEnter(event) {
+    const target = event.target;
     // delay opening tooltip
-    window.setTimeout(this.openTooltip, delay);
+    window.setTimeout(() => this.openTooltip(target), delay);
     // track hover state
     this.setState({ hover: true });
   }
 
   // open tooltip
-  openTooltip() {
+  openTooltip(target) {
     // if hitbox not being hovered anymore, cancel open
-    if (!this.state.hover)
+    // if target not specified, exit
+    if (!this.state.hover || !target)
       return;
 
     // get x/y position of hitbox to pass to tooltip popup
-    const left = this.hitbox.current.getBoundingClientRect().left;
-    const top = this.hitbox.current.getBoundingClientRect().top;
-
-    let x = left;
-    const y = top;
+    const left = target.getBoundingClientRect().left;
+    const top = target.getBoundingClientRect().top;
 
     // avoid scrunching tooltip too skinny when close to right side of view
-    if (x > window.innerWidth - 200)
-      x = window.innerWidth - 200;
+    const x = Math.min(left, window.innerWidth - 200);
+    const y = top;
 
     // open tooltip and update x/y position
     this.setState({ open: true, x: x, y: y });
@@ -64,16 +63,28 @@ export class Tooltip extends Component {
 
   // display component
   render() {
+    // mouse handler props to attach to children
+    const props = {
+      onMouseEnter: this.onMouseEnter,
+      onMouseLeave: this.onMouseLeave
+    };
+
+    // attach handler props to children
+    const children = React.Children.map(this.props.children, (element) => {
+      // if element is react element, create clone with attached props
+      if (React.isValidElement(element))
+        return React.cloneElement(element, props);
+      // if element is text node, wrap in span and attach props
+      else if (typeof element === 'string')
+        return <span {...props}>{element}</span>;
+      // otherwise, pass element through untouched
+      else
+        return element;
+    });
+
     return (
       <>
-        <span
-          ref={this.hitbox}
-          className='tooltip_hitbox'
-          onMouseEnter={this.onMouseEnter}
-          onMouseLeave={this.onMouseLeave}
-        >
-          {this.props.children}
-        </span>
+        {children}
         {this.state.open && this.props.text && (
           <Popup
             text={this.props.text}

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -20,15 +20,12 @@ export class Tooltip extends Component {
     this.state.y = 0;
     this.state.opacity = 0;
 
-    // a surrounding element that acts as detection box for mouse hover
-    this.hitbox = React.createRef();
-
     this.onMouseEnter = this.onMouseEnter.bind(this);
     this.openTooltip = this.openTooltip.bind(this);
     this.onMouseLeave = this.onMouseLeave.bind(this);
   }
 
-  // when mouse enters hitbox
+  // when mouse enters target
   onMouseEnter(event) {
     const target = event.target;
     // delay opening tooltip
@@ -39,12 +36,12 @@ export class Tooltip extends Component {
 
   // open tooltip
   openTooltip(target) {
-    // if hitbox not being hovered anymore, cancel open
+    // if target not being hovered anymore, cancel open
     // if target not specified, exit
     if (!this.state.hover || !target)
       return;
 
-    // get x/y position of hitbox to pass to tooltip popup
+    // get x/y position of target to pass to tooltip popup
     const left = target.getBoundingClientRect().left;
     const top = target.getBoundingClientRect().top;
 
@@ -56,7 +53,7 @@ export class Tooltip extends Component {
     this.setState({ open: true, x: x, y: y });
   }
 
-  // when mouse leaves hitbox
+  // when mouse leaves target
   onMouseLeave() {
     this.setState({ hover: false, open: false });
   }


### PR DESCRIPTION
Tooltips now don't need to wrap the children elements in hitboxes, the mouseenter and mouseleave events are attached directly to the children themselves. Also, the vertical position of the tooltip popup was changed to look a bit better and more consistent