### PR TITLE
Update API endpoint: query-metapaths

### DIFF
--- a/src/backend-query.js
+++ b/src/backend-query.js
@@ -12,7 +12,7 @@ const hetioStyles =
 // url for node search
 const nodeSearchServer = 'https://search-api.het.io/v1/nodes/';
 // url for metapaths search
-const metapathSearchServer = 'https://search-api.het.io/v1/querypair/';
+const metapathSearchServer = 'https://search-api.het.io/v1/query-metapaths/';
 
 // get resource at url and parse as json
 export function fetchJson(url) {


### PR DESCRIPTION
querypair was replaced with query-metapaths in
https://github.com/greenelab/hetmech-backend/commit/1c45611f587c9a104cc67d39a2273ba1f1dead2a