### PR TITLE
improve tooltip performance and positioning

### DIFF
--- a/src/tooltip.css
+++ b/src/tooltip.css
@@ -3,7 +3,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: fixed;
+  position: absolute;
   max-width: 320px;
   min-height: 30px;
   padding: 5px;
@@ -13,6 +13,7 @@
   transform: translate(0, calc(-100% - 5px));
   user-select: none;
   pointer-events: none;
+  z-index: 99999;
   transition: opacity 1s ease;
 }
 @media (hover: none) {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -42,8 +42,10 @@ export class Tooltip extends Component {
       return;
 
     // get x/y position of target to pass to tooltip popup
-    const left = target.getBoundingClientRect().left;
-    const top = target.getBoundingClientRect().top;
+    const left =
+      target.getBoundingClientRect().left + document.documentElement.scrollLeft;
+    const top =
+      target.getBoundingClientRect().top + document.documentElement.scrollTop;
 
     // avoid scrunching tooltip too skinny when close to right side of view
     const x = Math.min(left, window.innerWidth - 200);
@@ -60,6 +62,10 @@ export class Tooltip extends Component {
 
   // display component
   render() {
+    // if no specified text, skip attaching events and render
+    if (!this.props.text)
+      return <>{this.props.children}</>;
+
     // mouse handler props to attach to children
     const props = {
       onMouseEnter: this.onMouseEnter,


### PR DESCRIPTION
Changed tooltips from `fixed` position to `absolute` and also added a check in `render()` that improves performance a bit (when dealing with hundreds of instances of the tooltips, as we do encounter in the paths list).