### PR TITLE
change window width to body width

### DIFF
--- a/src/path-graph.js
+++ b/src/path-graph.js
@@ -96,7 +96,7 @@ export class PathGraph extends Component {
 
   // expand graph container to width of window
   expandContainer() {
-    const width = window.innerWidth - 20 - 20;
+    const width = document.body.clientWidth - 20 - 20;
     const height = (width * 3) / 4;
     this.setState({
       width: width,
@@ -181,7 +181,7 @@ export class PathGraph extends Component {
                 if (this.graph.current)
                   this.graph.current.fitView();
               }}
-              tooltipText='Fit the view to the graph'
+              tooltipText='Fit the view to the contents of the graph'
             />
             <TextButton
               text='.svg'
@@ -841,7 +841,7 @@ export class Graph extends Component {
     let left = 0;
     if (this.props.sectionWidth && this.props.width) {
       left = this.props.sectionWidth / 2 - this.props.width / 2;
-      const minLeft = this.props.sectionWidth / 2 - window.innerWidth / 2 + 20;
+      const minLeft = this.props.sectionWidth / 2 - document.body.clientWidth / 2 + 20;
       if (left < minLeft)
         left = minLeft;
     }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -50,7 +50,7 @@ export class Tooltip extends Component {
       target.getBoundingClientRect().top + document.documentElement.scrollTop;
 
     // avoid scrunching tooltip too skinny when close to right side of view
-    const x = Math.min(left, window.innerWidth - 200);
+    const x = Math.min(left, document.body.clientWidth - 200);
     const y = top;
 
     // open tooltip and update x/y position


### PR DESCRIPTION
This PR changes instances of `window.innerWidth` to `document.body.clientWidth` to attempt to get a more accurate reading of the width of the document.

I believe that `window.innerWidth` is returning not-intended results on mobile when the view is pinch-zoomed in. I think it is returning the width of the area visible on the screen, and not the full width of the `body` element as I intended.