### PR TITLE
CircleCI: fix missing ps command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - run:
           name: Frontend tests
           command: |
+            apt-get update && apt-get install procps --yes
             npm install
             npm test
             npm run build
@@ -43,7 +44,7 @@ jobs:
               --user "CircleCI Deploy Job <ci-build@circleci.com>" \
               --message \
             "Deploy webpage on `date --utc --iso-8601`
-            
+
             Builds https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1
             Pushed by $CIRCLE_BUILD_URL
 

--- a/kill-react-scripts.sh
+++ b/kill-react-scripts.sh
@@ -12,8 +12,8 @@ if [ -z "$PROCESSES" ]; then
 fi
 
 while read PROC; do
-  CMD=`awk '{print $8, $9, $10}' <<< $PROC`
-  PID=`awk '{print $2}' <<< $PROC`
-  echo "Killing: $CMD"
-  kill -9 $PID
+    CMD=`awk '{print $8, $9, $10}' <<< $PROC`
+    PID=`awk '{print $2}' <<< $PROC`
+    echo "Killing: $CMD"
+    kill -9 $PID
 done <<< $PROCESSES

--- a/kill-react-scripts.sh
+++ b/kill-react-scripts.sh
@@ -5,7 +5,7 @@
 
 echo "Killing all existing react-scripts processes ..."
 
-PROCESSES=`ps -ef | grep -i -E "react-scripts.*(start|test)" | grep -v grep`
+PROCESSES=`ps -ef | grep --extended-regexp "react-scripts.*(start|test)" | grep --invert-match grep`
 
 if [ -z "$PROCESSES" ]; then
     exit

--- a/kill-react-scripts.sh
+++ b/kill-react-scripts.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
+#
+# Kills all existing react-scripts processes and thus frees default port 3000
+# to be used by new react-scripts process.
 
-# kills any existing react-scripts processes and thus frees
-# default port 3000 to be used by new react-scripts instance
+echo "Killing all existing react-scripts processes ..."
 
-echo "killing any existing react-scripts instances"
+PROCESSES=`ps -ef | grep -i -E "react-scripts.*(start|test)" | grep -v grep`
 
-processes=`ps -ef | grep -i -E "react-scripts.*(start|test)"`
-while read process; do
-  echo killing process $process
-  processId=`awk '{print $2}' <<< $process`
-  kill -9 $processId
-done <<< $processes
+if [ -z "$PROCESSES" ]; then
+    exit
+fi
+
+while read PROC; do
+  CMD=`awk '{print $8, $9, $10}' <<< $PROC`
+  PID=`awk '{print $2}' <<< $PROC`
+  echo "Killing: $CMD"
+  kill -9 $PID
+done <<< $PROCESSES


### PR DESCRIPTION
This PR installs `procps` so that `ps` command will be available in docker container. Some error handling logic is also added in `kill-react-scripts.sh`.