### PR TITLE
add metapath count in node search results

### DIFF
--- a/src/backend-query.js
+++ b/src/backend-query.js
@@ -11,6 +11,9 @@ const hetioStyles =
   'https://raw.githubusercontent.com/hetio/hetionet/6e08d3039abaad8f6dafe26fe3b143773b0d7e51/describe/styles.json';
 // url for node search
 const nodeSearchServer = 'https://search-api.het.io/v1/nodes/';
+// url for node search with results sorted by metapath count
+const nodeSearchMetapathsServer =
+  'https://search-api.het.io/v1/count-metapaths-to/';
 // url for random node pair
 const randomNodeServer = 'https://search-api.het.io/v1/random-node-pair/';
 // url for metapaths search
@@ -61,13 +64,23 @@ export function lookupNodeById(id) {
 
 // search for nodes by string, and with metatype filter list
 // accepts comma-separated list of abbreviations of metatypes to include
-export function searchNodes(searchString, metatypes) {
+export function searchNodes(searchString, metatypes, otherNode) {
   const params = new URLSearchParams();
   params.set('search', searchString);
   params.set('limit', '100');
   if (metatypes)
     params.set('metanodes', metatypes);
+  if (otherNode)
+    params.set('count-metapaths-to', otherNode);
   const query = nodeSearchServer + '?' + params.toString();
+  return fetchJson(query).then((response) => {
+    return response.results;
+  });
+}
+
+// search for nodes sorted by metapath count
+export function searchNodesMetapaths(otherNode) {
+  const query = nodeSearchMetapathsServer + otherNode;
   return fetchJson(query).then((response) => {
     return response.results;
   });

--- a/src/node-search.css
+++ b/src/node-search.css
@@ -116,9 +116,17 @@
 }
 .node_search_results_item_name {
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.node_search_results_item_identifier {
+.node_search_results_item_count {
   margin-left: auto;
-  font-size: 0.75em;
   color: #757575;
+  font-size: 0.75em;
+  font-weight: 500;
+  width: 30px;
+  min-width: 30px;
+}
+.node_search_results_item_count svg {
+  margin-right: 3px;
 }

--- a/src/node-search.css
+++ b/src/node-search.css
@@ -124,9 +124,12 @@
   color: #757575;
   font-size: 0.75em;
   font-weight: 500;
-  width: 30px;
-  min-width: 30px;
+  width: 40px;
+  min-width: 40px;
+  vertical-align: middle;
 }
 .node_search_results_item_count svg {
+  height: 25px;
   margin-right: 3px;
+  vertical-align: middle;
 }

--- a/src/node-search.js
+++ b/src/node-search.js
@@ -234,6 +234,7 @@ class SourceNodeSearch extends Component {
   // when user makes a new node selection
   onChange(value) {
     this.props.dispatch(updateSourceTargetNodes({ sourceNode: value }));
+    // unfocus search box on selection
     if (value)
       document.activeElement.blur();
   }
@@ -268,6 +269,7 @@ class TargetNodeSearch extends Component {
   // when user makes a new node selection
   onChange(value) {
     this.props.dispatch(updateSourceTargetNodes({ targetNode: value }));
+    // unfocus search box on selection
     if (value)
       document.activeElement.blur();
   }
@@ -312,11 +314,15 @@ class SearchBox extends Component {
     if (this.props.otherNode && this.props.otherNode.id !== undefined)
       otherNodeId = this.props.otherNode.id;
 
+    // if one node selected and other node search box focused but empty,
+    // show list of nodes in order of metapath count
     if (searchString === '' && otherNodeId !== '') {
       searchNodesMetapaths(otherNodeId).then((results) =>
         this.setState({ searchResults: results || [] })
       );
-    } else {
+    } 
+    // otherwise, show normal search results based on search string
+    else {
       searchNodes(searchString, this.context.filterString, otherNodeId).then(
         (results) =>
           this.setState({ searchResults: results || [] })

--- a/src/node-search.js
+++ b/src/node-search.js
@@ -8,7 +8,6 @@ import Paper from '@material-ui/core/Paper';
 import MenuItem from '@material-ui/core/MenuItem';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons';
-import { faCodeBranch } from '@fortawesome/free-solid-svg-icons';
 import { faDice } from '@fortawesome/free-solid-svg-icons';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
@@ -23,6 +22,7 @@ import { updateSourceTargetNodes } from './actions.js';
 import { swapSourceTargetNodes } from './actions.js';
 import { sortCustom } from './util.js';
 import { copyObject } from './util.js';
+import { ReactComponent as PathIcon } from './path.svg';
 import './node-search.css';
 
 // node search section component
@@ -504,8 +504,10 @@ class Dropdown extends Component {
               </span>
               {this.props.showMetapathCount && (
                 <span className='node_search_results_item_count'>
-                  <FontAwesomeIcon icon={faCodeBranch} />
-                  {result.metapath_count || 0}
+                  <PathIcon />
+                  <span>
+                    {result.metapath_count || 0}
+                  </span>
                 </span>
               )}
             </MenuItem>

--- a/src/path.svg
+++ b/src/path.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="25" cy="65" r="10" fill="currentColor"></circle>
+  <circle cx="40" cy="35" r="10" fill="currentColor"></circle>
+  <circle cx="70" cy="50" r="10" fill="currentColor"></circle>
+  <path
+    fill="none"
+    stroke="currentColor"
+    stroke-width="5" 
+    d="
+      M 25 65
+      L 40 35
+      L 70 50
+    "
+  >
+  </path>
+</svg>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8326331/58112896-68955600-7bc2-11e9-813b-87979df141c9.png)

Note that I took out the `identifier` field from the search results. Does anyone really know those by heart such that they would recognize them? I know our `search` includes the `identifier` field too, but I don't envision people needing that there? It looks a bit crowded with both the metapath count and the identifier.