### PR TITLE
add commas to long numbers

### DIFF
--- a/src/metapath-results.js
+++ b/src/metapath-results.js
@@ -19,9 +19,11 @@ import { makeFilenameFriendly } from './util.js';
 import { downloadCsv } from './util.js';
 import { toFixed } from './util.js';
 import { toExponential } from './util.js';
+import { toComma } from './util.js';
 import { toGradient } from './util.js';
 import { sortCustom } from './util.js';
 import { copyObject } from './util.js';
+import { cutString } from './util.js';
 import { updateMetapaths } from './actions.js';
 import './metapath-results.css';
 
@@ -581,8 +583,8 @@ class TableBodyRow extends Component {
         />
         <TableBodyCell value={metapath.dgp_source_degree} />
         <TableBodyCell value={metapath.dgp_target_degree} />
-        <TableBodyCell value={metapath.dgp_n_dwpcs} />
-        <TableBodyCell value={metapath.dgp_n_nonzero_dwpcs} />
+        <TableBodyCell value={toComma(metapath.dgp_n_dwpcs)} />
+        <TableBodyCell value={toComma(metapath.dgp_n_nonzero_dwpcs)} />
         <TableBodyCell
           value={toFixed(metapath.dgp_nonzero_mean)}
           fullValue={metapath.dgp_nonzero_mean}
@@ -592,7 +594,7 @@ class TableBodyRow extends Component {
           fullValue={metapath.dgp_nonzero_sd}
         />
         <TableBodyCell
-          value='...'
+          value={cutString(metapath.cypher_query, 30)}
           fullValue={
             <textarea rows='4' cols='50'>
               {metapath.cypher_query}

--- a/src/metapath-results.js
+++ b/src/metapath-results.js
@@ -594,7 +594,7 @@ class TableBodyRow extends Component {
           fullValue={metapath.dgp_nonzero_sd}
         />
         <TableBodyCell
-          value={cutString(metapath.cypher_query, 30)}
+          value={cutString(metapath.cypher_query, 16)}
           fullValue={
             <textarea rows='4' cols='50'>
               {metapath.cypher_query}

--- a/src/styles.css
+++ b/src/styles.css
@@ -139,6 +139,10 @@ textarea {
     transform: translateX(-50%);
   }
 }
+textarea {
+  overflow: scroll;
+  white-space: nowrap;
+}
 table {
   border-collapse: collapse;
   width: 100%;
@@ -175,5 +179,5 @@ td > * {
   width: 300px;
 }
 .col_xxl {
-  width: 450px;
+  width: 600px;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -17,7 +17,7 @@ export function toFixed(number) {
   return <span>{parseFloat(number).toFixed(1)}</span>;
 }
 
-// split many-digit numbers by comma (or other, depending on locale)
+// split many-digit number by comma (or other, depending on locale)
 export function toComma(number) {
   return Number(number).toLocaleString();
 }

--- a/src/util.js
+++ b/src/util.js
@@ -17,6 +17,11 @@ export function toFixed(number) {
   return <span>{parseFloat(number).toFixed(1)}</span>;
 }
 
+// split many-digit numbers by comma (or other, depending on locale)
+export function toComma(number) {
+  return Number(number).toLocaleString();
+}
+
 // map number to css color (rgba or hex) based on specified gradient
 export function toGradient(number) {
   // pretty gradient


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8326331/58358202-f0da5c00-7e4b-11e9-9aaf-4beb17a95062.png)

- makes null dwpc super-column wider to accommodate longer numbers
- splits long numbers by comma (or locale specific)
- makes "short" value for query field a truncated version of query string instead of `...` to not mislead users that there was nothing returned
- makes query not line wrap in `textarea`, and force scroll in x and y

![image](https://user-images.githubusercontent.com/8326331/58358344-7d851a00-7e4c-11e9-816a-d667448d2a79.png)
