### PR TITLE
fix csv unicode symbol encoding

### DIFF
--- a/src/metapath-results.js
+++ b/src/metapath-results.js
@@ -658,6 +658,9 @@ function makeMetapathsTable(metapaths) {
       headers.push(field);
   }
 
+  // remove undesired fields
+  headers = headers.filter((header) => header !== 'cypher_query');
+
   // sort headers in custom order
   const order = [
     'id',

--- a/src/path-graph.js
+++ b/src/path-graph.js
@@ -1235,7 +1235,7 @@ class SelectedInfo extends Component {
     const cols = fields.map((field, index) => {
       return (
         <React.Fragment key={index}>
-          <td className='col_s small light'>
+          <td className='col_m small light'>
             <Tooltip text={field.tooltipText}>{field.firstCol}</Tooltip>
           </td>
           <td className='small'>{field.secondCol}</td>

--- a/src/styles.css
+++ b/src/styles.css
@@ -159,6 +159,7 @@ td {
   box-sizing: border-box;
   padding: 0;
   height: 28px;
+  word-break: break-word;
 }
 td > * {
   vertical-align: middle;

--- a/src/util.js
+++ b/src/util.js
@@ -92,7 +92,9 @@ export function toGradient(number) {
 // data in format [ [A1, B1] , [A2, B2] ]
 export function downloadCsv(data, filename) {
   const fileContent = data.map((cell) => cell.join(',')).join('\n');
-  const blob = new Blob([fileContent], { type: 'text/csv' });
+  const blob = new Blob(['\ufeff', fileContent], {
+    type: 'text/csv;charset=utf-16'
+  });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement('a');
   document.body.appendChild(link);

--- a/src/util.js
+++ b/src/util.js
@@ -93,7 +93,7 @@ export function toGradient(number) {
 export function downloadCsv(data, filename) {
   const fileContent = data.map((cell) => cell.join(',')).join('\n');
   const blob = new Blob(['\ufeff', fileContent], {
-    type: 'text/csv;charset=utf-16'
+    type: 'text/csv;charset=utf-8'
   });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement('a');


### PR DESCRIPTION
closes #74 and #75

According to @yhao-compbio, this PR fixes the issue on Microsoft Excel latest (2016?) but not on 2011, running on Mac. In my own testing, this seems to fix the issue for Libre Office Sheets on Ubuntu 18. I can wait to test this on my own Windows 10 machine at home, running the latest MS Office, if desired.