### PR TITLE
Backend query cache

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -40,11 +40,7 @@ export function swapSourceTargetNodes() {
 }
 
 // update metapaths
-export function updateMetapaths({
-  metapaths,
-  dontUpdateUrl,
-  preserveChecks
-}) {
+export function updateMetapaths({ metapaths, dontUpdateUrl, preserveChecks }) {
   return {
     type: 'update_metapaths',
     payload: { metapaths: metapaths },

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -20,4 +20,4 @@ test('renders without crashing', async () => {
   );
   expect(children).toBeGreaterThan(0);
   browser.close();
-}, 20000);
+}, 40000);

--- a/src/backend-query.js
+++ b/src/backend-query.js
@@ -22,11 +22,11 @@ const metapathSearchServer = 'https://search-api.het.io/v1/query-metapaths/';
 const pathSearchServer = 'https://search-api.het.io/v1/query-paths/';
 
 // get resource at url and parse as json
-export function fetchJson(url) {
+export function fetchJson(url, dontCache) {
   // check if query has already been made during this session
   // if so, use cache of that. if not, query server
   const cachedResponse = window.sessionStorage.getItem(url);
-  if (cachedResponse)
+  if (cachedResponse && !dontCache)
     return Promise.resolve(JSON.parse(cachedResponse));
   else {
     return fetch(url)
@@ -38,11 +38,13 @@ export function fetchJson(url) {
           return response.json();
       })
       .then((results) => {
-        try {
-          // save response to cache. use try/catch in case storage full
-          window.sessionStorage.setItem(url, JSON.stringify(results));
-        } catch (error) {
-          console.log(error, url);
+        if (!dontCache) {
+          try {
+            // save response to cache. use try/catch in case storage
+            window.sessionStorage.setItem(url, JSON.stringify(results));
+          } catch (error) {
+            console.log(error, url);
+          }
         }
         return results || {};
       })
@@ -108,7 +110,7 @@ export function searchNodesMetapaths(otherNode) {
 // get random source/target node pair that has metapath(s)
 export function getRandomNodePair() {
   const query = randomNodeServer;
-  return fetchJson(query).then((response) => {
+  return fetchJson(query, true).then((response) => {
     return response;
   });
 }

--- a/src/backend-query.js
+++ b/src/backend-query.js
@@ -24,7 +24,7 @@ const pathSearchServer = 'https://search-api.het.io/v1/query-paths/';
 // get resource at url and parse as json
 export function fetchJson(url) {
   // check if query has already been made during this session
-  // if so, use cache of that. if not, run backend query anew
+  // if so, use cache of that. if not, query server
   const cachedResponse = window.sessionStorage.getItem(url);
   if (cachedResponse)
     return Promise.resolve(JSON.parse(cachedResponse));
@@ -39,6 +39,7 @@ export function fetchJson(url) {
       })
       .then((results) => {
         try {
+          // save response to cache. use try/catch in case storage full
           window.sessionStorage.setItem(url, JSON.stringify(results));
         } catch (error) {
           console.log(error, url);

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ import { Provider } from 'react-redux';
 import { Reducer } from './reducers.js';
 import { App } from './app.js';
 
+// clear cache when app first starts (page refresh)
+window.sessionStorage.clear();
+
 // create global state store
 const store = createStore(Reducer, applyMiddleware(thunk));
 

--- a/src/metapath-results.js
+++ b/src/metapath-results.js
@@ -35,8 +35,7 @@ export class MetapathResults extends Component {
       <section>
         <CollapsibleSection
           label='Metapaths'
-          tooltipText=
-            'Metapaths of length <= 3 between the source and target node'
+          tooltipText='Metapaths of length <= 3 between the source and target node'
         >
           {this.props.metapaths.length > 0 ? <TableFull /> : <TableEmpty />}
         </CollapsibleSection>
@@ -440,7 +439,9 @@ class TableHead extends Component {
             <a
               href='https://neo4j.het.io/browser/'
               target='_blank'
-              rel='noopener noreferrer'>
+              rel='noopener noreferrer'
+              onClick={(event) => event.stopPropagation()}
+            >
               neo4j query
             </a>
           }

--- a/src/path-graph.js
+++ b/src/path-graph.js
@@ -953,7 +953,12 @@ export class Graph extends Component {
       pathQueries = this.props.pathQueries;
 
     // if pathQueries not valid, exit
-    if (!pathQueries || pathQueries.length <= 0)
+    if (
+      !pathQueries ||
+      pathQueries.length <= 0 ||
+      !pathQueries.paths ||
+      pathQueries.paths.length <= 0
+    )
       return graph;
 
     // get source/target nodes from first path in pathQueries

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -85,8 +85,6 @@ export function Reducer(prevState, action) {
     newState.metapaths = [];
   if (!newState.pathQueries)
     newState.pathQueries = [];
-  if (!newState.cacheStore)
-    newState.cacheStore = {};
 
   // update url after state change unless on redux initialization or
   // explicitly bypassed

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -15,63 +15,52 @@ export function Reducer(prevState, action) {
   switch (action.type) {
     // set definitions
     case 'set_definitions':
-      if (action.payload.metagraph !== undefined)
-        newState.metagraph = copyObject(action.payload.metagraph);
-      if (action.payload.hetioDefinitions !== undefined)
-        newState.hetioDefinitions = copyObject(action.payload.hetioDefinitions);
-      if (action.payload.hetioStyles !== undefined)
-        newState.hetioStyles = copyObject(action.payload.hetioStyles);
-      if (action.payload.hetmechDefinitions !== undefined) {
-        newState.hetmechDefinitions = copyObject(
-          action.payload.hetmechDefinitions
-        );
-      }
+      newState.metagraph = copyObject(action.payload.metagraph) || {};
+      newState.hetioDefinitions =
+        copyObject(action.payload.hetioDefinitions) || {};
+      newState.hetioStyles = copyObject(action.payload.hetioStyles) || {};
+      newState.hetmechDefinitions =
+        copyObject(action.payload.hetmechDefinitions) || {};
       break;
 
     // update source and/or target node
     case 'update_source_target_nodes':
       if (action.payload.sourceNode !== undefined)
-        newState.sourceNode = copyObject(action.payload.sourceNode);
+        newState.sourceNode = copyObject(action.payload.sourceNode) || {};
       if (action.payload.targetNode !== undefined)
-        newState.targetNode = copyObject(action.payload.targetNode);
+        newState.targetNode = copyObject(action.payload.targetNode) || {};
       break;
 
     // swap source/target nodes
     case 'swap_source_target_nodes':
-      if (prevState.sourceNode && prevState.targetNode) {
-        newState.sourceNode = copyObject(prevState.targetNode);
-        newState.targetNode = copyObject(prevState.sourceNode);
-      }
+      newState.sourceNode = copyObject(prevState.targetNode) || {};
+      newState.targetNode = copyObject(prevState.sourceNode) || {};
       break;
 
     // update metapaths
     case 'update_metapaths':
-      if (action.payload.metapaths !== undefined) {
-        newState.metapaths = copyObject(action.payload.metapaths);
-        if (action.preserveChecks === true) {
-          transferObjectProps(
-            prevState.metapaths,
-            newState.metapaths,
-            ['id'],
-            ['checked']
-          );
-        }
+      newState.metapaths = copyObject(action.payload.metapaths) || [];
+      if (action.preserveChecks === true) {
+        transferObjectProps(
+          prevState.metapaths,
+          newState.metapaths,
+          ['id'],
+          ['checked']
+        );
       }
       break;
 
     // update path queries
     case 'update_path_queries':
-      if (action.payload.pathQueries !== undefined) {
-        newState.pathQueries = copyObject(action.payload.pathQueries);
-        if (action.preserveChecks === true) {
-          transferQueryProps(
-            prevState.pathQueries,
-            newState.pathQueries,
-            'paths',
-            ['node_ids', 'rel_ids'],
-            ['checked', 'highlighted']
-          );
-        }
+      newState.pathQueries = copyObject(action.payload.pathQueries) || [];
+      if (action.preserveChecks === true) {
+        transferQueryProps(
+          prevState.pathQueries,
+          newState.pathQueries,
+          'paths',
+          ['node_ids', 'rel_ids'],
+          ['checked', 'highlighted']
+        );
       }
       break;
 
@@ -96,6 +85,8 @@ export function Reducer(prevState, action) {
     newState.metapaths = [];
   if (!newState.pathQueries)
     newState.pathQueries = [];
+  if (!newState.cacheStore)
+    newState.cacheStore = {};
 
   // update url after state change unless on redux initialization or
   // explicitly bypassed

--- a/src/util.js
+++ b/src/util.js
@@ -286,5 +286,8 @@ export function cutString(string, n) {
 // make deep copy of object. ensures everything is clone/copy, not reference.
 // works for everything except circular refs, functions, and js Dates
 export function copyObject(object) {
-  return JSON.parse(JSON.stringify(object));
+  if (object === undefined)
+    return;
+  else
+    return JSON.parse(JSON.stringify(object));
 }


### PR DESCRIPTION
closes #48 

This PR:
- automatically caches any queries to the backend in `sessionStorage`, and uses the cached response when the same query is made
- changes the null/undefined/falsey behavior in the master reducer
- doubles the timeout for the app render test, to hopefully prevent circleci tests from failing so often due to simple timeout
- adds error message for server non-successful response
- when clicking the link to the neo4j browser in the metapath table, it no longer sorts by that column
- fixes an app-crashing glitch where `path-query` returns no `paths` sub-object

By my eye, this PR can cut lag down anywhere from 25% to 75%.