### PR TITLE
fix bug where path graph never shows

### DIFF
--- a/src/path-graph.js
+++ b/src/path-graph.js
@@ -956,8 +956,8 @@ export class Graph extends Component {
     if (
       !pathQueries ||
       pathQueries.length <= 0 ||
-      !pathQueries.paths ||
-      pathQueries.paths.length <= 0
+      !pathQueries[0].paths ||
+      pathQueries[0].paths.length <= 0
     )
       return graph;
 


### PR DESCRIPTION
This PR fixes a regression from PR #77 where the path graph shows nothing even though there is valid node/edge data to show.