### PR TITLE
make precompute button always visible

### DIFF
--- a/src/metapath-results/attic.js
+++ b/src/metapath-results/attic.js
@@ -23,19 +23,21 @@ export class MetapathAttic extends Component {
 
     return (
       <div className='table_attic'>
-        <IconButton
-          text='.csv'
-          icon={faDownload}
-          className='link_button small'
-          onClick={() =>
-            download(
-              this.props.sourceNode,
-              this.props.targetNode,
-              this.props.metapaths
-            )
-          }
-          tooltipText='Download table as .csv file'
-        />
+        {this.props.metapaths.length > 0 && (
+          <IconButton
+            text='.csv'
+            icon={faDownload}
+            className='link_button small'
+            onClick={() =>
+              download(
+                this.props.sourceNode,
+                this.props.targetNode,
+                this.props.metapaths
+              )
+            }
+            tooltipText='Download table as .csv file'
+          />
+        )}
         <IconButton
           text='precomputed only'
           icon={faCheck}
@@ -45,16 +47,21 @@ export class MetapathAttic extends Component {
           tooltipText='Whether to show only precomputed metapaths, or show all
             metapaths. Warning: showing all can be slow.'
         />
-        <IconButton
-          text={this.props.showMore ? 'show less ' : 'show more '}
-          icon={this.props.showMore ? faAngleLeft : faAngleRight}
-          className='link_button small'
-          onClick={this.props.toggleShowMore}
-          tooltipText='Expand table and show more columns'
-        />
-        <div className='small light right'>
-          {metapathCount} results, {metapathSelectedCount} selected
-        </div>
+        <span />
+        {this.props.metapaths.length > 0 && (
+          <IconButton
+            text={this.props.showMore ? 'show less ' : 'show more '}
+            icon={this.props.showMore ? faAngleLeft : faAngleRight}
+            className='link_button small'
+            onClick={this.props.toggleShowMore}
+            tooltipText='Expand table and show more columns'
+          />
+        )}
+        {this.props.metapaths.length > 0 && (
+          <div className='small light right'>
+            {metapathCount} results, {metapathSelectedCount} selected
+          </div>
+        )}
       </div>
     );
   }

--- a/src/metapath-results/index.js
+++ b/src/metapath-results/index.js
@@ -26,29 +26,39 @@ export class MetapathResults extends Component {
 
   // display component
   render() {
+    let placeholder = <></>;
+    if (
+      this.props.sourceNode.id &&
+      this.props.targetNode.id &&
+      this.props.metapaths.length === 0
+    )
+      placeholder = <span className='light'>no results to show</span>;
+    if (!this.props.sourceNode.id || !this.props.targetNode.id) {
+      placeholder = (
+        <span className='light'>select a source and target node</span>
+      );
+    }
     return (
       <CollapsibleSection
         label='Metapaths'
         tooltipText='Metapaths of length <= 3 between the source and target
         node'
       >
-        {this.props.metapaths.length > 0 && (
-          <MetapathAttic
-            showMore={this.state.showMore}
-            toggleShowMore={this.toggleShowMore}
-          />
-        )}
+        <MetapathAttic
+          showMore={this.state.showMore}
+          toggleShowMore={this.toggleShowMore}
+        />
         {this.props.metapaths.length > 0 && (
           <MetapathTable showMore={this.state.showMore} />
         )}
-        {this.props.metapaths.length === 0 && (
-          <span className='light'>select a source and target node</span>
-        )}
+        {placeholder}
       </CollapsibleSection>
     );
   }
 }
 // connect component to global state
 MetapathResults = connect((state) => ({
+  sourceNode: state.sourceNode,
+  targetNode: state.targetNode,
   metapaths: state.metapaths
 }))(MetapathResults);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8326331/61801743-4eb00380-adfd-11e9-83b7-5c2811b000e7.png)

Makes it such that button is always visible. Also changes placeholder text to match the situation.