### PR TITLE
update

### DIFF
--- a/src/components/table.css
+++ b/src/components/table.css
@@ -77,5 +77,5 @@ th > .table_button {
   font-size: 0.8em;
 }
 td[data-highlighted='true'] {
-  background:#c0ecf8;
+  background: #c0ecf8;
 }

--- a/src/components/table.css
+++ b/src/components/table.css
@@ -76,3 +76,6 @@ th > .table_button {
   margin-left: 5px;
   font-size: 0.8em;
 }
+td[data-highlighted='true'] {
+  background:#c0ecf8;
+}

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -20,6 +20,7 @@ import { copyObject } from '../util/object.js';
 import './table.css';
 
 const rowIndexKey = '_rowIndex';
+const cellHighlightKey = '_cellHighlight';
 
 // generic table component
 // contains three sections: top (row above head), head, and body
@@ -79,7 +80,10 @@ export class Table extends Component {
     const newState = {};
 
     // when input data changes
-    if (!compareObjects(this.props.data, prevProps.data)) {
+    if (
+      !compareObjects(this.props.data, prevProps.data) ||
+      !compareObjects(this.props.headFields, prevProps.headFields)
+    ) {
       newState.indexedData = this.indexData(this.props.data);
       newState.sortedData = this.sortData(newState.indexedData);
       newState.filteredData = this.filterData(newState.sortedData);
@@ -228,13 +232,17 @@ export class Table extends Component {
       return data;
 
     return data.filter((datum) => {
-      for (const key of Object.keys(datum)) {
+      for (const field of this.props.headFields) {
         if (
-          String(datum[key])
+          datum[field] !== undefined &&
+          datum[field] !== null &&
+          JSON.stringify(datum[field])
             .toLowerCase()
             .includes(this.state.searchString.toLowerCase())
-        )
+        ) {
+          datum[cellHighlightKey] = field;
           return true;
+        }
       }
       return false;
     });
@@ -769,7 +777,15 @@ class BodyCell extends Component {
 
     return (
       <Tooltip text={tooltip}>
-        <td style={style} className={className}>
+        <td
+          style={style}
+          className={className}
+          data-highlighted={
+            this.props.datum[cellHighlightKey] === this.props.field
+              ? 'true'
+              : ''
+          }
+        >
           <DynamicField value={value} fullValue={fullValue} />
         </td>
       </Tooltip>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8326331/62075509-4697ff80-b213-11e9-9335-c15513013c7e.png)

Also makes search filter better. Makes it not catch unexpected things like `null`. And now it only searches the columns that are displayed, that is, the provided `headFields` prop. Before, it would search through the whole data set, even through keys that were never displayed anywhere, like `metapath_path_count_density`