### PR TITLE
move global.css to index.html and fix metapath button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- load global, site-wide styles from het.io -->
+  <link rel="stylesheet" type="text/css" href="https://het.io/global.css" />
 </head>
 <div
   id="root"

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -9,12 +9,12 @@
   flex-wrap: wrap;
   margin: 5px 0;
 }
-.table_attic > *:first-child {
+.table_attic > *:first-child:not(:last-child) {
   flex-grow: 1;
   padding-left: 10px;
 }
 @media screen and (max-width: 640px) {
-  .table_attic > *:first-child {
+  .table_attic > *:first-child:not(:last-child) {
     width: 100%;
     order: 1;
     margin-top: 5px;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -98,12 +98,6 @@ class App extends Component {
   render() {
     return (
       <>
-        {/* load global, site-wide styles from het.io */}
-        <link
-          rel='stylesheet'
-          type='text/css'
-          href='https://het.io/global.css'
-        />
         <NodeSearch />
         <NodeResults />
         <MetapathResults />

--- a/src/metapath-results/attic.js
+++ b/src/metapath-results/attic.js
@@ -52,7 +52,6 @@ export class MetapathAttic extends Component {
           tooltipText='Whether to show only precomputed metapaths, or show all
             metapaths. Warning: showing all can be slow.'
         />
-        <span />
         {this.props.metapaths.length > 0 && (
           <IconButton
             text={this.props.showMore ? 'collapse' : 'expand'}


### PR DESCRIPTION
- instead of including global.css in main App component, which makes it get fetched twice on het.io/search, put it in index.html which is not used in the deployed page
- fix "precomputed only" metapath button being full width