### PR TITLE
clean up backend queries

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -11,10 +11,10 @@ import { setPrecomputedMetapathsOnly } from '../metapath-results/actions.js';
 
 // get metagraph, hetio definitions, hetio styles, and hetmech definitions
 export async function fetchDefinitions() {
-  const metagraph = (await getMetagraph()) || {};
-  const hetioStyles = (await getHetioStyles()) || {};
-  const hetioDefinitions = (await getHetioDefinitions()) || {};
-  const hetmechDefinitions = (await getHetmechDefinitions()) || {};
+  const metagraph = await getMetagraph();
+  const hetioStyles = await getHetioStyles();
+  const hetioDefinitions = await getHetioDefinitions();
+  const hetmechDefinitions = await getHetmechDefinitions();
 
   // combine definitions into single convenient tooltipText lookup
   let tooltipDefinitions = {};
@@ -72,8 +72,11 @@ export function loadStateFromUrl() {
 
     const sourceNode = await lookupNodeById(sourceNodeId);
     const targetNode = await lookupNodeById(targetNodeId);
-    const metapaths =
-      (await searchMetapaths(sourceNodeId, targetNodeId, complete)) || [];
+    const metapaths = await searchMetapaths(
+      sourceNodeId,
+      targetNodeId,
+      complete
+    );
 
     // by the time awaits return, url may be different (eg if user
     // clicks back/forward quickly). if different, exit and allow more

--- a/src/metapath-results/actions.js
+++ b/src/metapath-results/actions.js
@@ -10,8 +10,11 @@ export async function fetchMetapaths({
   updateUrl,
   preserveChecks
 }) {
-  const metapaths =
-    (await searchMetapaths(sourceNodeId, targetNodeId, !precomputedOnly)) || [];
+  const metapaths = await searchMetapaths(
+    sourceNodeId,
+    targetNodeId,
+    !precomputedOnly
+  );
   return {
     metapaths: metapaths,
     updateUrl: updateUrl,
@@ -60,8 +63,7 @@ export async function fetchMetapathMissingData({
   updateUrl,
   preserveChecks
 }) {
-  const query =
-    (await searchPaths(sourceNodeId, targetNodeId, metapathId)) || {};
+  const query = await searchPaths(sourceNodeId, targetNodeId, metapathId);
 
   const newMetapaths = copyObject(metapaths);
 

--- a/src/metapath-results/reducers.js
+++ b/src/metapath-results/reducers.js
@@ -24,7 +24,7 @@ export function metapaths(state = [], action) {
       const newMetapaths = state;
 
       if (!action.payload || !action.payload.pathCountInfo)
-        return newMetapaths;
+        return newMetapaths || [];
 
       const pathCountInfo = action.payload.pathCountInfo;
 
@@ -37,7 +37,7 @@ export function metapaths(state = [], action) {
           ...pathCountInfo[key]
         };
       }
-      return newMetapaths;
+      return newMetapaths || [];
 
     default:
       return state;

--- a/src/node-search/actions.js
+++ b/src/node-search/actions.js
@@ -23,9 +23,9 @@ export function swapSourceTargetNode() {
 // fetch random pair of source/target nodes
 export function fetchRandomNodePair() {
   return async function(dispatch) {
-    const pair = (await getRandomNodePair()) || {};
-    const sourceNode = (await lookupNodeById(pair.source_id)) || {};
-    const targetNode = (await lookupNodeById(pair.target_id)) || {};
+    const pair = await getRandomNodePair();
+    const sourceNode = await lookupNodeById(pair.source_id);
+    const targetNode = await lookupNodeById(pair.target_id);
 
     dispatch(
       setSourceTargetNode({

--- a/src/path-results/actions.js
+++ b/src/path-results/actions.js
@@ -75,7 +75,6 @@ export function fetchAndSetPaths({
       updateUrl: updateUrl,
       preserveChecks: preserveChecks
     });
-
     dispatch(setPaths(paths));
   };
 }


### PR DESCRIPTION
- Add input checks to all queries so that query isn't made if the necessary parameters aren't provided (eg, searching for metapaths when the source or target node isn't selected)
- Moves default return values like `{}` and `[]` out of actions and all into `backend-queries.js`