### PR TITLE
fix non split build script

### DIFF
--- a/scripts/build-non-split.js
+++ b/scripts/build-non-split.js
@@ -14,6 +14,7 @@ config.optimization.splitChunks = {
 config.optimization.runtimeChunk = false;
 
 // JS
-config.output.filename = 'static/js/[name].js';
+config.output.filename = 'static/js/main.js';
 // CSS. "5" is MiniCssPlugin
-config.plugins[5].options.filename = 'static/css/[name].css';
+config.plugins[5].options.filename = 'static/css/main.css';
+config.plugins[5].options.moduleFilename = () => 'static/css/main.css';


### PR DESCRIPTION
@cgreene This seems to do it. The CSS now again outputs as `main.css` as expected, at least locally.

![image](https://user-images.githubusercontent.com/8326331/65377501-ebb2df80-dc7a-11e9-9180-fe9aec9654f3.png)
